### PR TITLE
add email & group query support

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -56,6 +56,8 @@ class Config {
 	const CONFIG_KEY_COUNT_USERS = 'count_users';
 	const CONFIG_KEY_GET_HOME = 'get_home';
 	const CONFIG_KEY_CREATE_USER = 'create_user';
+	const CONFIG_KEY_GET_EMAIL_ADDRESS = 'get_email_address';
+	const CONFIG_KEY_GET_GROUPS = 'get_groups';
 
 	private $logger;
 	private $appConfiguration;
@@ -216,6 +218,14 @@ class Config {
 
 	public function getQueryCreateUser() {
 		return $this->getQueryStringOrFalse(self::CONFIG_KEY_CREATE_USER);
+	}
+
+	public function getQueryGetEmailAddress() {
+		return $this->getQueryStringOrFalse(self::CONFIG_KEY_GET_EMAIL_ADDRESS);
+	}
+
+	public function getQueryGetGroups() {
+		return $this->getQueryStringOrFalse(self::CONFIG_KEY_GET_GROUPS);
 	}
 
 	/**

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -23,6 +23,8 @@ namespace OCA\UserBackendSqlRaw;
 
 use OCP\ILogger;
 use OC\User\Backend;
+use OCP\IUserManager;
+use OCP\IGroupManager;
 
 class UserBackend implements \OCP\IUserBackend, \OCP\UserInterface {
 
@@ -30,13 +32,17 @@ class UserBackend implements \OCP\IUserBackend, \OCP\UserInterface {
 	private $logContext = ['app' => 'user_backend_sql_raw'];
 	private $config;
 	private $db;
+	private $userManager;
+	private $groupManager;
 
-	public function __construct(ILogger $logger, Config $config, Db $db) {
+	public function __construct(ILogger $logger, Config $config, Db $db, IUserManager $userManager, IGroupManager $groupManager) {
 		$this->logger = $logger;
 		$this->config = $config;
 		// Don't get db handle (dbo object) here yet, so that it is only created
 		// when db queries are actually run.
 		$this->db = $db;
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
 	}
 
 	public function getBackendName() {
@@ -135,6 +141,8 @@ class UserBackend implements \OCP\IUserBackend, \OCP\UserInterface {
 		$statement = $this->db->getDbHandle()->prepare($this->config->getQueryGetDisplayName());
 		$statement->execute(['username' => $providedUsername]);
 		$retrievedDisplayName = $statement->fetchColumn();
+
+		$this->updateAttributes($providedUsername);
 		return $retrievedDisplayName;
 	}
 
@@ -258,6 +266,56 @@ class UserBackend implements \OCP\IUserBackend, \OCP\UserInterface {
 
 		}
 	}
+
+	public function updateAttributes($providedUsername) {
+		$retrievedEmailAddress = null; 
+		if(!empty($this->config->getQueryGetEmailAddress())) {
+			$statement = $this->db->getDbHandle()->prepare($this->config->getQueryGetEmailAddress());
+			$statement->execute(['username' => $providedUsername]);
+			$newEmailAddress = $statement->fetchColumn();
+		}
+		$user = $this->userManager->get($providedUsername);
+
+		$newGroups = null;
+		if(!empty($this->config->getQueryGetGroups())) {
+			$statement = $this->db->getDbHandle()->prepare($this->config->getQueryGetGroups());
+			$statement->execute(['username' => $providedUsername]);
+			$newGroups = $statement->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+			// Make sure that the user is always in the "everyone" group
+			if(!in_array('everyone', $newGroups)) {
+				$newGroups[] = 'everyone';
+			}
+		}
+
+		if ($user !== null) {
+			$currentEmailAddress = (string)$user->getEMailAddress();
+			if ($newEmailAddress !== null
+				&& $currentEmailAddress !== $newEmailAddress) {
+				$user->setEMailAddress($newEmailAddress);
+			}
+
+			if ($newGroups !== null) {
+				$groupManager = $this->groupManager;
+				$oldGroups = $groupManager->getUserGroupIds($user);
+
+				$groupsToAdd = array_unique(array_diff($newGroups, $oldGroups));
+				$groupsToRemove = array_diff($oldGroups, $newGroups);
+
+				foreach ($groupsToAdd as $group) {
+					if (!($groupManager->groupExists($group))) {
+						$groupManager->createGroup($group);
+					}
+					$groupManager->get($group)->addUser($user);
+				}
+
+				foreach ($groupsToRemove as $group) {
+					$groupManager->get($group)->removeUser($user);
+				}
+			}
+		}
+	}
+
 
 	/**
 	 * Escape % and _ with \.


### PR DESCRIPTION
I have implemented the two features:
- add email query support (closes #20) via query configured by value "get_email_address"
- add group support (closes #7) via query configured by value "get_groups"

I am using the app in addition to the user saml app, so I need to update the user information from another database that I have. The user information is updated via the updateAttributes function (similar as in the user saml app) which is triggered via the userExists function -> it may be called quite often, so maybe there is a better place to run it from. 