### PR TITLE
login case insensitive feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ This app has no user interface. All configuration is done via Nextcloud's system
        //'create_user' => 'INSERT INTO users (local, domain, password_hash) VALUES (split_part(:username, \'@\', 1), split_part(:username, \'@\', 2), :password_hash)',
   ),
  //'hash_algorithm_for_new_passwords' => 'bcrypt',
+ //'force_lowercase_login' => true,
  ),
  ```
 
-There are three types of configuration parameters:
+There are four types of configuration parameters:
 
 ### 1. Database
 
@@ -166,6 +167,17 @@ The config values are `md5`, `sha256`, `sha512`, `argon2i`, `argon2id` respectiv
   * This means, that your db can have different hash formats simultaneously. Whenever a
     user's password is changed, it will be updated to the configured hash algorithm. This eases
      migration to more modern algorithms.
+
+### 4. Optional features
+
+
+##### `force_lowercase_login`
+
+Default behavior of Nextcloud instance with internal user database is to apply submitted login information to lower case, so usernames are case insensitive.
+
+By design, this extention by default will transmit submitted usernames to Nextcloud once authenticated without lowercasing.
+
+If you want to keep default Nextcloud behavior, enable option `force_lowercase_login` and set it's value to `true`.
 
 ## Security
 

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -35,6 +35,7 @@ class Config
     const CONFIG_KEY_DB_PASSWORD = 'db_password';
     const CONFIG_KEY_DB_PASSWORD_FILE = 'db_password_file';
     const CONFIG_KEY_HASH_ALGORITHM_FOR_NEW_PASSWORDS = 'hash_algorithm_for_new_passwords';
+    const CONFIG_KEY_FORCE_LOWERCASE_LOGIN = 'force_lowercase_login';
 
     const CONFIG_KEY_QUERIES = 'queries';
     const CONFIG_KEY_GET_PASSWORD_HASH_FOR_USER = 'get_password_hash_for_user';
@@ -337,6 +338,12 @@ class Config
     private function normalize($string)
     {
         return strtolower(preg_replace("/[-_]/", "", $string));
+    }
+
+    // Nextcloud usualy don't use case sensitive login, so here is the option to keep
+    // standard behavior
+    public function forceLowercaseLogin() : bool {
+        return $this->getConfigValueOrFalse(self::CONFIG_KEY_FORCE_LOWERCASE_LOGIN) !== false;
     }
 
 }

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -87,6 +87,10 @@ class UserBackend implements \OCP\IUserBackend, \OCP\UserInterface
         }
 
         if (password_verify($providedPassword, $retrievedPasswordHash)) {
+            if ($this->config->forceLowercaseLogin()) {
+                $providedUsername = strtolower($providedUsername);
+            }
+
             return $providedUsername;
         } else {
             return false;


### PR DESCRIPTION
Adds an option to force lowercase provided login username to make login case insensitive, as Nextcloud normaly do when using internal user database
