### PR TITLE
feat(option to strip default realm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ This app has no user interface. All configuration is done via Nextcloud's system
        //'create_user' => 'INSERT INTO users (local, domain, password_hash) VALUES (split_part(:username, \'@\', 1), split_part(:username, \'@\', 2), :password_hash)',
   ),
  //'hash_algorithm_for_new_passwords' => 'bcrypt',
- ),
+ //'strip_login_realm' => 'example.com',
+),
  ```
 
-There are three types of configuration parameters:
+There are four types of configuration parameters:
 
 ### 1. Database
 
@@ -166,6 +167,17 @@ The config values are `md5`, `sha256`, `sha512`, `argon2i`, `argon2id` respectiv
   * This means, that your db can have different hash formats simultaneously. Whenever a
     user's password is changed, it will be updated to the configured hash algorithm. This eases
      migration to more modern algorithms.
+
+### 4. Optional features
+
+
+##### `strip_login_realm`
+
+If your Nextcloud instance uses many domains/realms for your users and you implemented a feature of allowing users of one domain/realm to log with or without the @domain part, then you can use this configuration parameter to set the default realm to use.
+
+If set, the string will be removed from the username used as login user, but only if it is at the end of the string.
+
+You can set it with or without the '@' sign, it will be automaticaly added if needed.
 
 ## Security
 

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -35,6 +35,7 @@ class Config
     const CONFIG_KEY_DB_PASSWORD = 'db_password';
     const CONFIG_KEY_DB_PASSWORD_FILE = 'db_password_file';
     const CONFIG_KEY_HASH_ALGORITHM_FOR_NEW_PASSWORDS = 'hash_algorithm_for_new_passwords';
+    const CONFIG_KEY_STRIP_LOGIN_REALM = 'strip_login_realm';
 
     const CONFIG_KEY_QUERIES = 'queries';
     const CONFIG_KEY_GET_PASSWORD_HASH_FOR_USER = 'get_password_hash_for_user';
@@ -338,5 +339,13 @@ class Config
     {
         return strtolower(preg_replace("/[-_]/", "", $string));
     }
+
+    // option to strip @realm part of provided username. Usefull for instances dealing with
+    // multiple domains where one domain should be the 'default' or 'implicit' domain.
+    // This allows to make login 'foo_user@default_domain.ext' identical to 'foo_user'
+    public function stripLoginRealm() {
+        return $this->getConfigValueOrFalse(self::CONFIG_KEY_STRIP_LOGIN_REALM);
+    }
+
 
 }

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -87,6 +87,15 @@ class UserBackend implements \OCP\IUserBackend, \OCP\UserInterface
         }
 
         if (password_verify($providedPassword, $retrievedPasswordHash)) {
+            $strip_realm = $this->config->stripLoginRealm();
+            if ($strip_realm) {
+                $strip_realm = str_replace('.', '\\.', $strip_realm);
+                if (substr($strip_realm, 0, 1) != '@') {
+                    $strip_realm = "@$strip_realm";
+                }
+                $providedUsername = preg_replace("/$strip_realm$/", '', $providedUsername);
+            }
+
             return $providedUsername;
         } else {
             return false;


### PR DESCRIPTION
add configuration option to add behavior similar to other external user authentication apps: 

For Nextcloud instances using multiple domains / realms, configured with a 'default' domain, which is not required for a user to log in, this option will facilitate migration to user_backend_sql_raw and adoption.

This feature allow administrator to define a domain that will be stripped out from provided username, allowing users from that domain to autenthify without need to specify the domain part.